### PR TITLE
ci: add committer details to release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,4 +16,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_COMMITTER_NAME: "Paul Tibbetts"
+          GIT_COMMITTER_EMAIL: "paul.tibbetts@stickee.co.uk"
         run: npx semantic-release


### PR DESCRIPTION
This should fix #4 not being released because the action didn't have access to the protected branch.